### PR TITLE
fix: order node links so critical arrows appear on top

### DIFF
--- a/lib/utlis/Pert.ts
+++ b/lib/utlis/Pert.ts
@@ -226,7 +226,7 @@ class Pert {
       }
     });
 
-    this.links = linkData;
+    this.links = linkData.sort((a, b) => Number(a.critical) - Number(b.critical));
   }
 
   private calcCriticalPaths() {


### PR DESCRIPTION
Only line 229 was applied